### PR TITLE
Refactoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ MAINTAINER Tarjei N Skrede "tarjei.skrede@sesam.io"
 COPY ./service /service
 WORKDIR /service
 
-RUN pip install --upgrade pip && pip install -r requirements.txt && chmod -x ./service.py
+RUN apk add build-base &&  pip install --upgrade pip && pip install -r requirements.txt && chmod -x ./service.py && \
+apk del build-base && apk add 'libstdc++'
 
 EXPOSE 5000/tcp
 

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.22.0
 Flask==1.1.1
 CherryPy==18.1.2
+python-rapidjson==0.8.0

--- a/service/service.py
+++ b/service/service.py
@@ -99,7 +99,7 @@ def get_entities_per_project(projects, path, args):
             exc_flag = "un"
             if response.text:
                 logging.error(f'Response: {response.text}')
-            if response.status_code <= 500:
+            if response.status_code >= 500:
                 raise exc
 
         logging.debug(f"project {str(project)} executed {exc_flag}successfully")

--- a/service/service.py
+++ b/service/service.py
@@ -99,6 +99,9 @@ def get_entities_per_project(projects, path, args):
             exc_flag = "un"
             if response.text:
                 logging.error(f'Response: {response.text}')
+            if response.status_code <= 500:
+                raise exc
+
         logging.debug(f"project {str(project)} executed {exc_flag}successfully")
 
 


### PR DESCRIPTION
 : replaced built in json package with more performant rapidjson
: bumped amount of cherrypy threads 10 -> 32 as we already have ~20 long running pipes
: new query parameter 'projects' with comma separated project ids to limit projects for each pipe
: better error logging
: Now service will fail fast on all HTTP 500+ errors from MIPS